### PR TITLE
Add Map function with tests and examples

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -1,6 +1,9 @@
 package godash
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 func Example() {
 	s := []int{-2 - 1, 0, 1, 2, 3, 4}
@@ -23,4 +26,15 @@ func ExampleEvery() {
 	// Output:
 	// true
 	// false
+}
+
+func ExampleMap() {
+	doubleToString := func(i int) (string, error) {
+		return strconv.Itoa(i * 2), nil
+	}
+	input := []int{0, 1, 2, 3, 4}
+
+	fmt.Println(Map(input, doubleToString))
+	// Output:
+	// [0 2 4 6 8] <nil>
 }

--- a/godash.go
+++ b/godash.go
@@ -50,3 +50,19 @@ func Find[T any, S ~[]T](s S, p func(T) bool) (T, bool) {
 	var zero T
 	return zero, false
 }
+
+// Map takes in a slice of input values and a mapper function, and applies the mapper function to each
+// input value. It returns a new slice containing the mapped values. If any error occurs during the mapping
+// process, the function aborts and returns nil along with the error. Otherwise, it returns the new slice
+// of mapped values and a nil error.
+func Map[TInput any, TOutput any, S ~[]TInput](s S, mapper func(TInput) (TOutput, error)) ([]TOutput, error) {
+	result := make([]TOutput, len(s))
+	for i, value := range s {
+		mapped, err := mapper(value)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = mapped
+	}
+	return result, nil
+}

--- a/godash_test.go
+++ b/godash_test.go
@@ -1,7 +1,9 @@
 package godash
 
 import (
+	"errors"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -397,4 +399,50 @@ func TestFindIndex(t *testing.T) {
 	t.Run("slices of a type alias", func(t *testing.T) {
 		// TODO
 	})
+}
+
+func TestMap(t *testing.T) {
+	tt := []struct {
+		name     string
+		input    []int
+		expected []string
+		mapper   func(int) (string, error)
+		err      error
+	}{{
+		name:     "simple",
+		input:    []int{1, 2, 3},
+		expected: []string{"2", "4", "6"},
+		mapper: func(i int) (string, error) {
+			return strconv.Itoa(i * 2), nil
+		},
+		err: nil,
+	}, {
+		name:     "empty input",
+		input:    []int{},
+		expected: []string{},
+		mapper: func(i int) (string, error) {
+			return strconv.Itoa(i), nil
+		},
+		err: nil,
+	}, {
+		name:     "mapper error",
+		input:    []int{1, 2, 3},
+		expected: nil,
+		mapper: func(i int) (string, error) {
+			return "", errors.New("error")
+		},
+		err: errors.New("error"),
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := Map(tc.input, tc.mapper)
+			if !reflect.DeepEqual(tc.expected, actual) {
+				t.Errorf("expected %v, got %v", tc.expected, actual)
+			}
+			if !reflect.DeepEqual(tc.err, err) {
+				t.Errorf("expected err %v, got %v", tc.err, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes #6 

The new Map function has been added to the GoDash library. This function maps input values using a provided mapper function and returns a slice of mapped values. Test cases and examples to illustrate the usage of this new function have also been included.