### PR TITLE
Add IndexOf() to ComparableSlice in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ The [Slices](https://pkg.go.dev/github.com/taciogt/godash#Slice) type are a cust
 * [Reduce()](https://pkg.go.dev/github.com/taciogt/godash#Reduce)
 
 Some extra functionality is supported by the more specific [ComparableSlice](https://pkg.go.dev/github.com/taciogt/godash#ComparableSlice) type: 
-* [Includes()](https://pkg.go.dev/github.com/taciogt/godash#CoparableSlice.Includes)
+* 
+* [Includes()](https://pkg.go.dev/github.com/taciogt/godash#ComparableSlice.Includes)
+* [IndexOf()](https://pkg.go.dev/github.com/taciogt/godash#ComparableSlice.IndexOf)
 
 ## References
 


### PR DESCRIPTION
Updated the README.md to include the IndexOf() method under the ComparableSlice functionality section. This ensures documentation remains consistent with the available library features.