### PR TITLE
#25 Use a generic struct for comparable slices

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ['1.21', '1.22', '1.23' ]
+        go-version: ['1.21', '1.22', '1.23', '1.24' ]
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The [Slices](https://pkg.go.dev/github.com/taciogt/godash#Slice) type are a cust
 * [Reduce()](https://pkg.go.dev/github.com/taciogt/godash#Reduce)
 * [Pop()](https://pkg.go.dev/github.com/taciogt/godash#Slice.Pop)
 
-Some extra functionality is supported by the more specific [ComparableSlice](https://pkg.go.dev/github.com/taciogt/godash#ComparableSlice) type: 
-* 
+Some extra functionality is supported by the more specific [ComparableSlice](https://pkg.go.dev/github.com/taciogt/godash#ComparableSlice) type:
+
 * [Includes()](https://pkg.go.dev/github.com/taciogt/godash#ComparableSlice.Includes)
 * [IndexOf()](https://pkg.go.dev/github.com/taciogt/godash#ComparableSlice.IndexOf)
 

--- a/comparable_slices.go
+++ b/comparable_slices.go
@@ -3,66 +3,70 @@ package godash
 // ComparableSlice is a generic slice type that restricts its elements to types that satisfy the comparable constraint.
 // It extends the behavior of the standard Slice with some extra functionality that don't require predicates,
 // like the Includes method.
-type ComparableSlice[T comparable] Slice[T]
+type ComparableSlice[T comparable] struct {
+	Slice[T]
+}
+
+//type ComparableSlice[T comparable] Slice[T]
 
 func NewComparableSlice[T comparable](elems ...T) ComparableSlice[T] {
-	return elems
+	return ComparableSlice[T]{NewSlice(elems...)}
 }
 
 // ToRawSlice converts the generic ComparableSlice[T] into a standard Go slice []T,
 // maintaining all elements in their order.
 func (s ComparableSlice[T]) ToRawSlice() []T {
-	return s
+	return s.Slice
 }
 
-// At behaves as the method [Slice.At]
-func (s ComparableSlice[T]) At(index int) T {
-	return At[T](Slice[T](s), index)
-}
-
-// Every behaves as the method [Slice.Every]
-func (s ComparableSlice[T]) Every(p Predicate[T]) bool {
-	return Every(Slice[T](s), p)
-}
-
-// Fill behaves as the method [Slice.Fill]
-func (s ComparableSlice[T]) Fill(value T, positions ...int) ComparableSlice[T] {
-	return Fill(Slice[T](s), value, positions...)
-}
-
-// Filter behaves as the method [Slice.Filter]
-func (s ComparableSlice[T]) Filter(p Predicate[T]) ComparableSlice[T] {
-	return Filter(Slice[T](s), p)
-}
-
-// Find behaves as the method [Slice.Find]
-func (s ComparableSlice[T]) Find(p Predicate[T]) (T, bool) {
-	return Find(Slice[T](s), p)
-}
-
-// FindIndex behaves as the method [Slice.FindIndex]
-func (s ComparableSlice[T]) FindIndex(p Predicate[T]) (int, bool) {
-	return FindIndex(Slice[T](s), p)
-}
-
-// FindLast behaves as the method [Slice.FindLast]
-func (s ComparableSlice[T]) FindLast(p Predicate[T]) (T, bool) {
-	return FindLast(Slice[T](s), p)
-}
-
-// FindLastIndex behaves as the method [Slice.FindLastIndex]
-func (s ComparableSlice[T]) FindLastIndex(p Predicate[T]) (int, bool) {
-	return FindLastIndex(Slice[T](s), p)
-}
-
-func (s ComparableSlice[T]) ForEach(f func(i int, v T)) {
-	ForEach(Slice[T](s), f)
-}
+//// At behaves as the method [Slice.At]
+//func (s ComparableSlice[T]) At(index int) T {
+//	return At[T](s.Slice[T](s), index)
+//}
+//
+//// Every behaves as the method [Slice.Every]
+//func (s ComparableSlice[T]) Every(p Predicate[T]) bool {
+//	return Every(Slice[T](s), p)
+//}
+//
+//// Fill behaves as the method [Slice.Fill]
+//func (s ComparableSlice[T]) Fill(value T, positions ...int) ComparableSlice[T] {
+//	return Fill(Slice[T](s), value, positions...)
+//}
+//
+//// Filter behaves as the method [Slice.Filter]
+//func (s ComparableSlice[T]) Filter(p Predicate[T]) ComparableSlice[T] {
+//	return Filter(Slice[T](s), p)
+//}
+//
+//// Find behaves as the method [Slice.Find]
+//func (s ComparableSlice[T]) Find(p Predicate[T]) (T, bool) {
+//	return Find(Slice[T](s), p)
+//}
+//
+//// FindIndex behaves as the method [Slice.FindIndex]
+//func (s ComparableSlice[T]) FindIndex(p Predicate[T]) (int, bool) {
+//	return FindIndex(Slice[T](s), p)
+//}
+//
+//// FindLast behaves as the method [Slice.FindLast]
+//func (s ComparableSlice[T]) FindLast(p Predicate[T]) (T, bool) {
+//	return FindLast(Slice[T](s), p)
+//}
+//
+//// FindLastIndex behaves as the method [Slice.FindLastIndex]
+//func (s ComparableSlice[T]) FindLastIndex(p Predicate[T]) (int, bool) {
+//	return FindLastIndex(Slice[T](s), p)
+//}
+//
+//func (s ComparableSlice[T]) ForEach(f func(i int, v T)) {
+//	ForEach(Slice[T](s), f)
+//}
 
 // Includes checks whether the specified value exists within the given ComparableSlice.
 // Returns true if found, false otherwise.
 func Includes[T comparable](s ComparableSlice[T], value T) bool {
-	for _, v := range s {
+	for _, v := range s.Slice {
 		if v == value {
 			return true
 		}
@@ -77,7 +81,7 @@ func (s ComparableSlice[T]) Includes(value T) bool {
 }
 
 func IndexOf[T comparable](s ComparableSlice[T], value T) (int, bool) {
-	return FindIndex(s, func(v T) bool {
+	return s.Slice.FindIndex(func(v T) bool {
 		return v == value
 	})
 }

--- a/comparable_slices.go
+++ b/comparable_slices.go
@@ -39,11 +39,11 @@ func (s ComparableSlice[T]) IndexOf(value T) (int, bool) {
 	return IndexOf(s, value)
 }
 
-// Pop removes and returns the last element of the ComparableSlice.
-// If the slice is empty, it returns the zero value of type T and false.
-func (s *ComparableSlice[T]) Pop() (T, bool) {
-	rawSlice := s.ToRawSlice()
-	result, ok := Pop(&rawSlice)
-	*s = NewComparableSlice(rawSlice...)
-	return result, ok
-}
+//// Pop removes and returns the last element of the ComparableSlice.
+//// If the slice is empty, it returns the zero value of type T and false.
+//func (s *ComparableSlice[T]) Pop() (T, bool) {
+//	rawSlice := s.ToRawSlice()
+//	result, ok := Pop(&rawSlice)
+//	*s = NewComparableSlice(rawSlice...)
+//	return result, ok
+//}

--- a/comparable_slices.go
+++ b/comparable_slices.go
@@ -7,8 +7,6 @@ type ComparableSlice[T comparable] struct {
 	Slice[T]
 }
 
-//type ComparableSlice[T comparable] Slice[T]
-
 func NewComparableSlice[T comparable](elems ...T) ComparableSlice[T] {
 	return ComparableSlice[T]{NewSlice(elems...)}
 }

--- a/comparable_slices.go
+++ b/comparable_slices.go
@@ -13,12 +13,6 @@ func NewComparableSlice[T comparable](elems ...T) ComparableSlice[T] {
 	return ComparableSlice[T]{NewSlice(elems...)}
 }
 
-// ToRawSlice converts the generic ComparableSlice[T] into a standard Go slice []T,
-// maintaining all elements in their order.
-func (s ComparableSlice[T]) ToRawSlice() []T {
-	return s.Slice
-}
-
 // Includes checks whether the specified value exists within the given ComparableSlice.
 // Returns true if found, false otherwise.
 func Includes[T comparable](s ComparableSlice[T], value T) bool {

--- a/comparable_slices.go
+++ b/comparable_slices.go
@@ -13,8 +13,9 @@ func NewComparableSlice[T comparable](elems ...T) ComparableSlice[T] {
 
 // Includes checks whether the specified value exists within the given ComparableSlice.
 // Returns true if found, false otherwise.
-func Includes[T comparable](s ComparableSlice[T], value T) bool {
-	for _, v := range s.Slice {
+func Includes[T comparable, S ~[]T](s S, value T) bool {
+	// TODO implement the Some method and refactor to use it
+	for _, v := range s {
 		if v == value {
 			return true
 		}
@@ -25,7 +26,7 @@ func Includes[T comparable](s ComparableSlice[T], value T) bool {
 
 // Includes behaves exactly like [Includes] function, except it is called directly on the slice.
 func (s ComparableSlice[T]) Includes(value T) bool {
-	return Includes(s, value)
+	return Includes(s.Slice, value)
 }
 
 func IndexOf[T comparable](s ComparableSlice[T], value T) (int, bool) {

--- a/comparable_slices.go
+++ b/comparable_slices.go
@@ -1,8 +1,8 @@
 package godash
 
 // ComparableSlice is a generic slice type that restricts its elements to types that satisfy the comparable constraint.
-// It extends the behavior of the standard Slice with some extra functionality that don't require predicates,
-// like the Includes method.
+// It extends the behavior of the standard Slice with some extra functionalities that don't require predicates,
+// like the [Includes] and [IndexOf] methods.
 type ComparableSlice[T comparable] struct {
 	Slice[T]
 }

--- a/comparable_slices.go
+++ b/comparable_slices.go
@@ -30,7 +30,7 @@ func (s ComparableSlice[T]) Includes(value T) bool {
 }
 
 func IndexOf[T comparable](s ComparableSlice[T], value T) (int, bool) {
-	return s.Slice.FindIndex(func(v T) bool {
+	return s.FindIndex(func(v T) bool {
 		return v == value
 	})
 }
@@ -38,12 +38,3 @@ func IndexOf[T comparable](s ComparableSlice[T], value T) (int, bool) {
 func (s ComparableSlice[T]) IndexOf(value T) (int, bool) {
 	return IndexOf(s, value)
 }
-
-//// Pop removes and returns the last element of the ComparableSlice.
-//// If the slice is empty, it returns the zero value of type T and false.
-//func (s *ComparableSlice[T]) Pop() (T, bool) {
-//	rawSlice := s.ToRawSlice()
-//	result, ok := Pop(&rawSlice)
-//	*s = NewComparableSlice(rawSlice...)
-//	return result, ok
-//}

--- a/comparable_slices.go
+++ b/comparable_slices.go
@@ -19,50 +19,6 @@ func (s ComparableSlice[T]) ToRawSlice() []T {
 	return s.Slice
 }
 
-//// At behaves as the method [Slice.At]
-//func (s ComparableSlice[T]) At(index int) T {
-//	return At[T](s.Slice[T](s), index)
-//}
-//
-//// Every behaves as the method [Slice.Every]
-//func (s ComparableSlice[T]) Every(p Predicate[T]) bool {
-//	return Every(Slice[T](s), p)
-//}
-//
-//// Fill behaves as the method [Slice.Fill]
-//func (s ComparableSlice[T]) Fill(value T, positions ...int) ComparableSlice[T] {
-//	return Fill(Slice[T](s), value, positions...)
-//}
-//
-//// Filter behaves as the method [Slice.Filter]
-//func (s ComparableSlice[T]) Filter(p Predicate[T]) ComparableSlice[T] {
-//	return Filter(Slice[T](s), p)
-//}
-//
-//// Find behaves as the method [Slice.Find]
-//func (s ComparableSlice[T]) Find(p Predicate[T]) (T, bool) {
-//	return Find(Slice[T](s), p)
-//}
-//
-//// FindIndex behaves as the method [Slice.FindIndex]
-//func (s ComparableSlice[T]) FindIndex(p Predicate[T]) (int, bool) {
-//	return FindIndex(Slice[T](s), p)
-//}
-//
-//// FindLast behaves as the method [Slice.FindLast]
-//func (s ComparableSlice[T]) FindLast(p Predicate[T]) (T, bool) {
-//	return FindLast(Slice[T](s), p)
-//}
-//
-//// FindLastIndex behaves as the method [Slice.FindLastIndex]
-//func (s ComparableSlice[T]) FindLastIndex(p Predicate[T]) (int, bool) {
-//	return FindLastIndex(Slice[T](s), p)
-//}
-//
-//func (s ComparableSlice[T]) ForEach(f func(i int, v T)) {
-//	ForEach(Slice[T](s), f)
-//}
-
 // Includes checks whether the specified value exists within the given ComparableSlice.
 // Returns true if found, false otherwise.
 func Includes[T comparable](s ComparableSlice[T], value T) bool {

--- a/comparable_slices_test.go
+++ b/comparable_slices_test.go
@@ -585,7 +585,6 @@ func TestComparableSlice_Pop(t *testing.T) {
 					t.Errorf("resulting %v, want %v", s.Slice, tt.expectedSlice)
 				}
 			})
-
 		})
 	}
 }

--- a/comparable_slices_test.go
+++ b/comparable_slices_test.go
@@ -573,18 +573,16 @@ func TestComparableSlice_Pop(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Run("method on ComparableSlice", func(t *testing.T) {
-				s := NewComparableSlice(tt.slice...)
+			s := NewComparableSlice(tt.slice...)
 
-				gotResult, gotOk := s.Pop()
-				if gotResult != tt.expectedResult || gotOk != tt.expectedOk {
-					t.Errorf("Slice.Pop() = (%v, %v), want (%v, %v)", gotResult, gotOk, tt.expectedResult, tt.expectedOk)
-				}
+			gotResult, gotOk := s.Pop()
+			if gotResult != tt.expectedResult || gotOk != tt.expectedOk {
+				t.Errorf("Slice.Pop() = (%v, %v), want (%v, %v)", gotResult, gotOk, tt.expectedResult, tt.expectedOk)
+			}
 
-				if !reflect.DeepEqual(s.ToRawSlice(), tt.expectedSlice) {
-					t.Errorf("resulting %v, want %v", s.Slice, tt.expectedSlice)
-				}
-			})
+			if !reflect.DeepEqual(s.ToRawSlice(), tt.expectedSlice) {
+				t.Errorf("resulting %v, want %v", s.ToRawSlice(), tt.expectedSlice)
+			}
 		})
 	}
 }

--- a/comparable_slices_test.go
+++ b/comparable_slices_test.go
@@ -122,7 +122,7 @@ func TestComparableSlice_Fill(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotSlice := tt.slice.Fill(tt.value, tt.positions...)
-			if !slices.Equal(gotSlice, tt.expectedSlice) {
+			if !slices.Equal(gotSlice, tt.expectedSlice.Slice) {
 				t.Errorf("Fill() = %v, want %v", gotSlice, tt.expectedSlice)
 			}
 		})
@@ -158,7 +158,7 @@ func TestComparableSlice_Filter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.slice.Filter(tt.predicate)
-			if !slices.Equal(got, tt.expected) {
+			if !slices.Equal(got, tt.expected.Slice) {
 				t.Errorf("Filter() = %v, want %v", got, tt.expected)
 			}
 		})
@@ -338,7 +338,7 @@ func TestComparableSlice_ForEach(t *testing.T) {
 		s.ForEach(func(i int, v int) {
 			v *= 2
 		})
-		if !slices.Equal(s, NewComparableSlice(1, 2, 3)) {
+		if !slices.Equal(s.Slice, NewComparableSlice(1, 2, 3).Slice) {
 			t.Error("function should not change input slice")
 		}
 	})
@@ -366,27 +366,27 @@ func TestIncludes(t *testing.T) {
 		expected bool
 	}{{
 		name:     "element exists in slice",
-		slice:    ComparableSlice[int]{1, 2, 3, 4, 5},
+		slice:    NewComparableSlice(1, 2, 3, 4, 5),
 		search:   3,
 		expected: true,
 	}, {
 		name:     "element does not exist in slice",
-		slice:    ComparableSlice[int]{1, 2, 3, 4, 5},
+		slice:    NewComparableSlice(1, 2, 3, 4, 5),
 		search:   6,
 		expected: false,
 	}, {
 		name:     "empty slice",
-		slice:    ComparableSlice[int]{},
+		slice:    NewComparableSlice[int](),
 		search:   1,
 		expected: false,
 	}, {
 		name:     "slice with duplicates contains the element",
-		slice:    ComparableSlice[int]{1, 2, 2, 3, 3},
+		slice:    NewComparableSlice(1, 2, 2, 3, 3),
 		search:   2,
 		expected: true,
 	}, {
 		name:     "slice with negative numbers contains the element",
-		slice:    ComparableSlice[int]{-1, -2, -3, -4},
+		slice:    NewComparableSlice(-1, -2, -3, -4),
 		search:   -3,
 		expected: true,
 	}}
@@ -401,7 +401,7 @@ func TestIncludes(t *testing.T) {
 	}
 
 	t.Run("string slices", func(t *testing.T) {
-		slice := ComparableSlice[string]{"apple", "banana", "cherry"}
+		slice := NewComparableSlice[string]("apple", "banana", "cherry")
 		if !slice.Includes("banana") {
 			t.Errorf("Includes() = false, want true for 'banana'")
 		}
@@ -415,10 +415,10 @@ func TestIncludes(t *testing.T) {
 			id   int
 			name string
 		}
-		slice := ComparableSlice[customStruct]{
-			{id: 1, name: "Alice"},
-			{id: 2, name: "Bob"},
-		}
+		slice := NewComparableSlice[customStruct](
+			customStruct{id: 1, name: "Alice"},
+			customStruct{id: 2, name: "Bob"},
+		)
 		search := customStruct{id: 1, name: "Alice"}
 		if !slice.Includes(search) {
 			t.Errorf("Includes() = false, want true for %v", search)
@@ -445,7 +445,7 @@ func TestIndexOf(t *testing.T) {
 		expectedExists: true,
 	}, {
 		name:           "element does not exist in slice",
-		slice:          ComparableSlice[int]{1, 2, 3, 4, 5},
+		slice:          NewComparableSlice(1, 2, 3, 4, 5),
 		search:         6,
 		expectedIndex:  -1,
 		expectedExists: false,
@@ -457,25 +457,25 @@ func TestIndexOf(t *testing.T) {
 		expectedExists: false,
 	}, {
 		name:           "first element in slice",
-		slice:          ComparableSlice[int]{7, 8, 9},
+		slice:          NewComparableSlice(7, 8, 9),
 		search:         7,
 		expectedIndex:  0,
 		expectedExists: true,
 	}, {
 		name:           "last element in slice",
-		slice:          ComparableSlice[int]{10, 20, 30},
+		slice:          NewComparableSlice(10, 20, 30),
 		search:         30,
 		expectedIndex:  2,
 		expectedExists: true,
 	}, {
 		name:           "slice with duplicates",
-		slice:          ComparableSlice[int]{1, 2, 2, 3, 3},
+		slice:          NewComparableSlice(1, 2, 2, 3, 3),
 		search:         2,
 		expectedIndex:  1,
 		expectedExists: true,
 	}, {
 		name:           "slice with negative numbers",
-		slice:          ComparableSlice[int]{-1, -2, -3, -4},
+		slice:          NewComparableSlice(-1, -2, -3, -4),
 		search:         -3,
 		expectedIndex:  2,
 		expectedExists: true,
@@ -492,7 +492,7 @@ func TestIndexOf(t *testing.T) {
 	}
 
 	t.Run("string slices", func(t *testing.T) {
-		slice := ComparableSlice[string]{"apple", "banana", "cherry"}
+		slice := NewComparableSlice[string]("apple", "banana", "cherry")
 		index, exists := slice.IndexOf("banana")
 		if index != 1 || !exists {
 			t.Errorf("IndexOf() = %v, %v, want 1, true for 'banana'", index, exists)
@@ -509,11 +509,11 @@ func TestIndexOf(t *testing.T) {
 			id   int
 			name string
 		}
-		slice := ComparableSlice[customStruct]{
-			{id: 1, name: "Alice"},
-			{id: 2, name: "Bob"},
-			{id: 3, name: "Charlie"},
-		}
+		slice := NewComparableSlice[customStruct](
+			customStruct{id: 1, name: "Alice"},
+			customStruct{id: 2, name: "Bob"},
+			customStruct{id: 3, name: "Charlie"},
+		)
 		search := customStruct{id: 2, name: "Bob"}
 		index, exists := slice.IndexOf(search)
 		if index != 1 || !exists {
@@ -531,57 +531,43 @@ func TestIndexOf(t *testing.T) {
 func TestComparableSlice_Pop(t *testing.T) {
 	tests := []struct {
 		name           string
-		slice          ComparableSlice[int]
+		slice          []int
 		expectedResult int
 		expectedOk     bool
-		expectedSlice  ComparableSlice[int]
+		expectedSlice  []int
 	}{{
 		name:           "Pop from non-empty slice",
-		slice:          ComparableSlice[int]{1, 2, 3},
+		slice:          []int{1, 2, 3},
 		expectedResult: 3,
 		expectedOk:     true,
-		expectedSlice:  ComparableSlice[int]{1, 2},
+		expectedSlice:  []int{1, 2},
 	}, {
 		name:           "Pop from single-element slice",
-		slice:          ComparableSlice[int]{10},
+		slice:          []int{10},
 		expectedResult: 10,
 		expectedOk:     true,
-		expectedSlice:  ComparableSlice[int]{},
+		expectedSlice:  []int{},
 	}, {
 		name:           "Pop from empty slice",
-		slice:          ComparableSlice[int]{},
+		slice:          []int{},
 		expectedResult: 0, // Default value for int
 		expectedOk:     false,
-		expectedSlice:  ComparableSlice[int]{},
+		expectedSlice:  []int{},
 	},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Run("standalone function", func(t *testing.T) {
-				s := make([]int, len(tt.slice))
-				copy(s, tt.slice)
-
-				gotResult, gotOk := Pop(&s)
-				if gotResult != tt.expectedResult || gotOk != tt.expectedOk {
-					t.Errorf("Pop() = (%v, %v), want (%v, %v)", gotResult, gotOk, tt.expectedResult, tt.expectedOk)
-				}
-
-				if !reflect.DeepEqual(s, tt.expectedSlice.ToRawSlice()) {
-					t.Errorf("resulting ComparableSlice = %v, want %v", s, tt.expectedSlice)
-				}
-			})
-
 			t.Run("method on ComparableSlice", func(t *testing.T) {
-				s := NewComparableSlice[int](tt.slice...)
-				gotResult, gotOk := s.Pop()
+				s := NewComparableSlice(tt.slice...)
 
+				gotResult, gotOk := s.Pop()
 				if gotResult != tt.expectedResult || gotOk != tt.expectedOk {
 					t.Errorf("Slice.Pop() = (%v, %v), want (%v, %v)", gotResult, gotOk, tt.expectedResult, tt.expectedOk)
 				}
 
-				if !reflect.DeepEqual(s, tt.expectedSlice) {
-					t.Errorf("resulting ComparableSlice = %v, want %v", s, tt.expectedSlice)
+				if !reflect.DeepEqual(s.ToRawSlice(), tt.expectedSlice) {
+					t.Errorf("resulting %v, want %v", s.Slice, tt.expectedSlice)
 				}
 			})
 

--- a/comparable_slices_test.go
+++ b/comparable_slices_test.go
@@ -361,42 +361,57 @@ func TestComparableSlice_ForEach(t *testing.T) {
 func TestIncludes(t *testing.T) {
 	tests := []struct {
 		name     string
-		slice    ComparableSlice[int]
+		slice    []int
 		search   int
 		expected bool
 	}{{
 		name:     "element exists in slice",
-		slice:    NewComparableSlice(1, 2, 3, 4, 5),
+		slice:    []int{1, 2, 3, 4, 5},
 		search:   3,
 		expected: true,
 	}, {
 		name:     "element does not exist in slice",
-		slice:    NewComparableSlice(1, 2, 3, 4, 5),
+		slice:    []int{1, 2, 3, 4, 5},
 		search:   6,
 		expected: false,
 	}, {
 		name:     "empty slice",
-		slice:    NewComparableSlice[int](),
+		slice:    []int{},
+		search:   1,
+		expected: false,
+	}, {
+		name:     "nil slice",
+		slice:    nil,
 		search:   1,
 		expected: false,
 	}, {
 		name:     "slice with duplicates contains the element",
-		slice:    NewComparableSlice(1, 2, 2, 3, 3),
+		slice:    []int{1, 2, 2, 3, 3},
 		search:   2,
 		expected: true,
 	}, {
 		name:     "slice with negative numbers contains the element",
-		slice:    NewComparableSlice(-1, -2, -3, -4),
+		slice:    []int{-1, -2, -3, -4},
 		search:   -3,
 		expected: true,
 	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.slice.Includes(tt.search)
-			if got != tt.expected {
-				t.Errorf("Includes() = %v, want %v", got, tt.expected)
-			}
+			t.Run("standalone function", func(t *testing.T) {
+				got := Includes(tt.slice, tt.search)
+				if got != tt.expected {
+					t.Errorf("Includes() = %v, want %v", got, tt.expected)
+				}
+			})
+
+			t.Run("receiver method", func(t *testing.T) {
+				slice := NewComparableSlice(tt.slice...)
+				got := slice.Includes(tt.search)
+				if got != tt.expected {
+					t.Errorf("Includes() = %v, want %v", got, tt.expected)
+				}
+			})
 		})
 	}
 

--- a/example_comparable_slice_test.go
+++ b/example_comparable_slice_test.go
@@ -1,0 +1,16 @@
+package godash_test
+
+import (
+	"fmt"
+	"github.com/taciogt/godash"
+)
+
+func ExampleComparableSlice_Includes() {
+	slice := godash.NewComparableSlice(1, 2, 3)
+	fmt.Println(slice.Includes(2))
+	fmt.Println(slice.Includes(4))
+
+	// Output:
+	// true
+	// false
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Restructured the `ComparableSlice` type for improved organization and encapsulation, removing several redundant methods.

- **Tests**
  - Updated test cases to ensure consistent instantiation and accurate comparisons with the new `ComparableSlice` structure.
  - Introduced a new example test function demonstrating the usage of the `Includes` method.

- **Documentation**
  - Improved formatting in the README for the `ComparableSlice` section for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->