### PR TITLE
Add Reverse function for slices and method for Slice type

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ The [`Slice`](https://pkg.go.dev/github.com/taciogt/godash#Slice) type extends t
 
 #### Basic Slice Methods
 
-| Method                                                                           | Description                                 |
-|----------------------------------------------------------------------------------|---------------------------------------------|
-| [`At(index int)`](https://pkg.go.dev/github.com/taciogt/godash#Slice.At)         | Returns the element at the specified index  |
-| [`Fill(value T)`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Fill)       | Fills all elements with the specified value |
-| [`Pop()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Pop)                | Removes and returns the last element        |
-| [`Push(elements ...T)`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Push) | Adds elements to the end of the slice       |
-| [`Reverse()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Reverse)        | Reverse the elements of the slice in place  |
+| Method                                                                           | Description                                                    |
+|----------------------------------------------------------------------------------|----------------------------------------------------------------|
+| [`At(index int)`](https://pkg.go.dev/github.com/taciogt/godash#Slice.At)         | Returns the element at the specified index                     |
+| [`Fill(value T)`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Fill)       | Fills all elements with the specified value                    |
+| [`Pop()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Pop)                | Removes and returns the last element                           |
+| [`Push(elements ...T)`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Push) | Adds elements to the end of the slice                          |
+| [`Reverse()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Reverse)        | Reverse the elements of the slice in place                     |
+| [`ToReversed()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.ToReversed)  | Creates and returns a new slice with elements in reverse order |
 
 #### Iteration and Transformation
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The [`Slice`](https://pkg.go.dev/github.com/taciogt/godash#Slice) type extends t
 | [`Fill(value T)`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Fill)       | Fills all elements with the specified value |
 | [`Pop()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Pop)                | Removes and returns the last element        |
 | [`Push(elements ...T)`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Push) | Adds elements to the end of the slice       |
+| [`Reverse()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Reverse)        | Reverse the elements of the slice in place  |
 
 #### Iteration and Transformation
 

--- a/example_slice_test.go
+++ b/example_slice_test.go
@@ -198,3 +198,25 @@ func ExampleSlice_Reverse() {
 	// reversed integers slice: [5 4 3 2 1]
 	// reversed and filtered: [6 4 2]
 }
+
+func ExampleToReversed() {
+	nums := []int{1, 2, 3, 4, 5}
+	reversed := godash.ToReversed(nums)
+	fmt.Println("reversed slice:", reversed)
+	fmt.Println("original slice (unchanged):", nums)
+
+	// Output:
+	// reversed slice: [5 4 3 2 1]
+	// original slice (unchanged): [1 2 3 4 5]
+}
+
+func ExampleSlice_ToReversed() {
+	s := godash.NewSlice(1, 2, 3, 4, 5)
+	reversed := s.ToReversed()
+	fmt.Println("reversed slice:", reversed)
+	fmt.Println("original slice (unchanged):", s)
+
+	// Output:
+	// reversed slice: [5 4 3 2 1]
+	// original slice (unchanged): [1 2 3 4 5]
+}

--- a/example_slice_test.go
+++ b/example_slice_test.go
@@ -167,3 +167,34 @@ func ExampleReduceRight() {
 	// Output:
 	// fun is Go <nil>
 }
+
+func ExampleReverse() {
+	// Reverse a slice of integers
+	nums := []int{1, 2, 3, 4, 5}
+	reversed := godash.Reverse(nums)
+	fmt.Println("reversed integers:", reversed)
+	fmt.Println("original slice (modified):", nums)
+
+	// Output:
+	// reversed integers: [5 4 3 2 1]
+	// original slice (modified): [5 4 3 2 1]
+}
+
+func ExampleSlice_Reverse() {
+	// Create and reverse a slice of integers using the method
+	s := godash.NewSlice(1, 2, 3, 4, 5)
+	s.Reverse()
+	fmt.Println("reversed integers slice:", s)
+
+	// Chaining with other methods
+	s2 := godash.NewSlice(1, 2, 3, 4, 5, 6)
+	isEven := func(n int) bool { return n%2 == 0 }
+
+	// Chain operations: reverse the slice, then filter for even numbers
+	result := s2.Reverse().Filter(isEven)
+	fmt.Println("reversed and filtered:", result)
+
+	// Output:
+	// reversed integers slice: [5 4 3 2 1]
+	// reversed and filtered: [6 4 2]
+}

--- a/slices.go
+++ b/slices.go
@@ -297,3 +297,20 @@ func Reverse[T any, S ~[]T](s S) S {
 func (s Slice[T]) Reverse() Slice[T] {
 	return Reverse(s)
 }
+
+// ToReversed returns a new slice with the elements of the input slice reversed,
+// preserving the original slice unmodified.
+func ToReversed[T any, S ~[]T](s S) []T {
+	result := make([]T, len(s))
+	l := len(s)
+	for i := len(s) - 1; i >= 0; i-- {
+		result[i] = s[l-1-i]
+	}
+	return result
+}
+
+// ToReversed creates and returns a new slice with elements in reverse order,
+// leaving the original slice unchanged.
+func (s Slice[T]) ToReversed() Slice[T] {
+	return ToReversed(s)
+}

--- a/slices.go
+++ b/slices.go
@@ -282,3 +282,18 @@ func ReduceRight[TIn any, TOut any, S ~[]TIn](s S, reducer func(acc TOut, curr T
 
 	return acc, nil
 }
+
+// Reverse reverses the elements of a slice in place.
+// This function modifies the original slice and returns it.
+func Reverse[T any, S ~[]T](s S) S {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+	return s
+}
+
+// Reverse reverses the elements of the slice in place.
+// This method modifies the original slice and returns the modified slice for chaining.
+func (s Slice[T]) Reverse() Slice[T] {
+	return Reverse(s)
+}

--- a/slices_test.go
+++ b/slices_test.go
@@ -1128,6 +1128,7 @@ func TestReverse(t *testing.T) {
 						t.Errorf("Reverse(%v) = %v, want %v", tt.input, got, tt.want)
 					}
 				})
+
 				t.Run("method on slice type", func(t *testing.T) {
 					inputCopy := make([]string, len(tt.input))
 					copy(inputCopy, tt.input)
@@ -1139,7 +1140,6 @@ func TestReverse(t *testing.T) {
 						t.Errorf("s.Reverse() = %v, want %v", gotSlice, tt.want)
 					}
 				})
-
 			})
 		}
 	})

--- a/slices_test.go
+++ b/slices_test.go
@@ -1031,3 +1031,116 @@ func TestReduceRight(t *testing.T) {
 		}
 	})
 }
+
+func TestReverse(t *testing.T) {
+	t.Run("integer slices", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input []int
+			want  []int
+		}{{
+			name:  "odd length slice",
+			input: []int{1, 2, 3, 4, 5},
+			want:  []int{5, 4, 3, 2, 1},
+		}, {
+			name:  "even length slice",
+			input: []int{1, 2, 3, 4},
+			want:  []int{4, 3, 2, 1},
+		}, {
+			name:  "single element slice",
+			input: []int{42},
+			want:  []int{42},
+		}, {
+			name:  "empty slice",
+			input: []int{},
+			want:  []int{},
+		}, {
+			name:  "negative integers",
+			input: []int{-3, -2, -1, 0},
+			want:  []int{0, -1, -2, -3},
+		}}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Run("standalone function", func(t *testing.T) {
+					// Test the standalone function
+					inputCopy := make([]int, len(tt.input))
+					copy(inputCopy, tt.input)
+
+					got := Reverse(inputCopy)
+					if !reflect.DeepEqual(got, tt.want) {
+						t.Errorf("Reverse(%v) = %v, want %v", tt.input, got, tt.want)
+					}
+					if !reflect.DeepEqual(inputCopy, tt.want) {
+						t.Errorf("original slice wasn't modified in-place. got=%v, want=%v", inputCopy, tt.want)
+					}
+				})
+
+				t.Run("method on slice type", func(t *testing.T) {
+					inputCopy := make([]int, len(tt.input))
+					copy(inputCopy, tt.input)
+
+					s := NewSlice(inputCopy...)
+					gotSlice := s.Reverse()
+
+					if !reflect.DeepEqual(gotSlice, Slice[int](tt.want)) {
+						t.Errorf("s.Reverse() = %v, want %v", gotSlice, tt.want)
+					}
+					if !reflect.DeepEqual(s, Slice[int](tt.want)) {
+						t.Errorf("original Slice wasn't modified in-place. Got %v, want %v", s, tt.want)
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("string slices", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input []string
+			want  []string
+		}{{
+			name:  "words",
+			input: []string{"hello", "world", "go", "reverse"},
+			want:  []string{"reverse", "go", "world", "hello"},
+		}, {
+			name:  "empty strings present",
+			input: []string{"", "abc", "", "def"},
+			want:  []string{"def", "", "abc", ""},
+		}, {
+			name:  "single string",
+			input: []string{"singleton"},
+			want:  []string{"singleton"},
+		}, {
+			name:  "empty slice",
+			input: []string{},
+			want:  []string{},
+		}}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Run("standalone function", func(t *testing.T) {
+					inputCopy := make([]string, len(tt.input))
+					copy(inputCopy, tt.input)
+
+					got := Reverse(inputCopy)
+					if !reflect.DeepEqual(got, tt.want) {
+						t.Errorf("Reverse(%v) = %v, want %v", tt.input, got, tt.want)
+					}
+				})
+				t.Run("method on slice type", func(t *testing.T) {
+					inputCopy := make([]string, len(tt.input))
+					copy(inputCopy, tt.input)
+
+					s := NewSlice(inputCopy...)
+					gotSlice := s.Reverse()
+
+					if !reflect.DeepEqual(gotSlice, Slice[string](tt.want)) {
+						t.Errorf("s.Reverse() = %v, want %v", gotSlice, tt.want)
+					}
+				})
+
+			})
+		}
+	})
+}

--- a/slices_test.go
+++ b/slices_test.go
@@ -1144,3 +1144,67 @@ func TestReverse(t *testing.T) {
 		}
 	})
 }
+
+func TestToReversed(t *testing.T) {
+	t.Run("integer slices", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input []int
+			want  []int
+		}{{
+			name:  "odd length slice",
+			input: []int{1, 2, 3, 4, 5},
+			want:  []int{5, 4, 3, 2, 1},
+		}, {
+			name:  "even length slice",
+			input: []int{1, 2, 3, 4},
+			want:  []int{4, 3, 2, 1},
+		}, {
+			name:  "single element slice",
+			input: []int{42},
+			want:  []int{42},
+		}, {
+			name:  "empty slice",
+			input: []int{},
+			want:  []int{},
+		}, {
+			name:  "negative integers",
+			input: []int{-3, -2, -1, 0},
+			want:  []int{0, -1, -2, -3},
+		}}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Run("standalone function", func(t *testing.T) {
+					// Test the standalone function
+					inputCopy := make([]int, len(tt.input))
+					copy(inputCopy, tt.input)
+
+					got := ToReversed(inputCopy)
+					if !reflect.DeepEqual(got, tt.want) {
+						t.Errorf("Reverse(%v) = %v, want %v", tt.input, got, tt.want)
+					}
+					if !reflect.DeepEqual(inputCopy, tt.input) {
+						t.Errorf("original slice was modified in-place. got=%v, want=%v", inputCopy, tt.want)
+					}
+				})
+
+				t.Run("method on slice type", func(t *testing.T) {
+					inputCopy := make([]int, len(tt.input))
+					copy(inputCopy, tt.input)
+
+					s := NewSlice(inputCopy...)
+					gotSlice := s.ToReversed()
+
+					if !reflect.DeepEqual(gotSlice, Slice[int](tt.want)) {
+						t.Errorf("s.Reverse() = %v, want %v", gotSlice, tt.want)
+					}
+					if !reflect.DeepEqual(s, Slice[int](tt.input)) {
+						t.Errorf("original Slice wasn't modified in-place. Got %v, want %v", s, tt.want)
+					}
+				})
+			})
+		}
+	})
+
+}


### PR DESCRIPTION
Introduce a generic Reverse function to reverse slice elements in place. Additionally, add a Reverse method for the Slice type to allow method chaining. These changes enhance slice manipulation capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an in-place reversal feature for collections, allowing you to easily flip the order of elements while supporting method chaining for more streamlined operations.
	- Added a non-destructive reversal option that returns a new reversed slice without altering the original.
- **Documentation**
	- Updated documentation to include the new `Reverse()` and `ToReversed()` methods for the `Slice` type, detailing their functionalities.
- **Tests**
	- Enhanced test coverage with examples demonstrating the use of the new reversal functionality for both standalone and method calls, including various edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->