### PR TITLE
Implement the shift and unshift methods on the slice type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ The [`Slice`](https://pkg.go.dev/github.com/taciogt/godash#Slice) type extends t
 | [`Pop()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Pop)                | Removes and returns the last element                           |
 | [`Push(elements ...T)`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Push) | Adds elements to the end of the slice                          |
 | [`Reverse()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Reverse)        | Reverse the elements of the slice in place                     |
-| [`Shift()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Shift)            | Removes and returns the first element of the provided slice    |
+| [`Shift()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Shift)            | Removes and returns the first element of the slice             |
+| [`Unshift()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Unshift)        | Prepends one or more values to the beginning of the slice      |
 | [`ToReversed()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.ToReversed)  | Creates and returns a new slice with elements in reverse order |
 
 #### Iteration and Transformation

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The [`Slice`](https://pkg.go.dev/github.com/taciogt/godash#Slice) type extends t
 | [`Pop()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Pop)                | Removes and returns the last element                           |
 | [`Push(elements ...T)`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Push) | Adds elements to the end of the slice                          |
 | [`Reverse()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Reverse)        | Reverse the elements of the slice in place                     |
+| [`Shift()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.Shift)            | Removes and returns the first element of the provided slice    |
 | [`ToReversed()`](https://pkg.go.dev/github.com/taciogt/godash#Slice.ToReversed)  | Creates and returns a new slice with elements in reverse order |
 
 #### Iteration and Transformation

--- a/example_slice_test.go
+++ b/example_slice_test.go
@@ -220,3 +220,35 @@ func ExampleSlice_ToReversed() {
 	// reversed slice: [5 4 3 2 1]
 	// original slice (unchanged): [1 2 3 4 5]
 }
+
+func ExampleShift() {
+	s := []int{1, 2, 3, 4, 5}
+	element, ok := godash.Shift(&s)
+	fmt.Println("non-empty slice")
+	fmt.Println(element, ok)
+	fmt.Println(s)
+
+	emptySlice := []int{}
+	element, ok = godash.Shift(&emptySlice)
+	fmt.Println("empty slice")
+	fmt.Println(element, ok)
+	fmt.Println(emptySlice)
+
+	// Output:
+	// non-empty slice
+	// 1 true
+	// [2 3 4 5]
+	// empty slice
+	// 0 false
+	// []
+}
+
+func ExampleSlice_Shift() {
+	s := godash.NewSlice(1, 2, 3, 4, 5)
+	element, ok := s.Shift()
+	fmt.Println(element, ok)
+	fmt.Println(s)
+	// Output:
+	// 1 true
+	// [2 3 4 5]
+}

--- a/example_slice_test.go
+++ b/example_slice_test.go
@@ -252,3 +252,21 @@ func ExampleSlice_Shift() {
 	// 1 true
 	// [2 3 4 5]
 }
+
+func ExampleUnshift() {
+	s := []int{3, 4, 5}
+	fmt.Println(godash.Unshift(&s, 1, 2))
+	fmt.Println(s)
+	// Output:
+	// 5
+	// [1 2 3 4 5]
+}
+
+func ExampleSlice_Unshift() {
+	s := godash.NewSlice(3, 4, 5)
+	fmt.Println(s.Unshift(1, 2))
+	fmt.Println(s)
+	// Output:
+	// 5
+	// [1 2 3 4 5]
+}

--- a/slices.go
+++ b/slices.go
@@ -314,3 +314,25 @@ func ToReversed[T any, S ~[]T](s S) []T {
 func (s Slice[T]) ToReversed() Slice[T] {
 	return ToReversed(s)
 }
+
+// Shift removes and returns the first element of the provided slice, modifying the original slice.
+// If the slice is empty, it returns the zero value of type `T` and `false`.
+func Shift[T any, S ~*[]T](s S) (T, bool) {
+	length := len(*s)
+	if length == 0 {
+		var zero T
+		return zero, false
+	}
+	firstElem := (*s)[0]
+	*s = (*s)[1:]
+	return firstElem, true
+}
+
+// Shift removes and returns the first element of the slice, updating the original slice.
+// If the slice is empty, it returns the zero value of type `T` and `false`.
+func (s *Slice[T]) Shift() (T, bool) {
+	rawSlice := s.ToRaw()
+	result, ok := Shift(&rawSlice)
+	*s = NewSlice(rawSlice...)
+	return result, ok
+}

--- a/slices.go
+++ b/slices.go
@@ -336,3 +336,31 @@ func (s *Slice[T]) Shift() (T, bool) {
 	*s = NewSlice(rawSlice...)
 	return result, ok
 }
+
+// Unshift prepends one or more values to the beginning of the provided slice pointer
+// and returns the new length of the slice.
+//
+// Parameters:
+//   - value: One or more values of type T to be added to the beginning of the slice.
+//
+// Returns:
+//   - length: The new length of the slice after the values have been prepended.
+func Unshift[T any, S ~*[]T](s S, value ...T) (length int) {
+	*s = append(value, *s...)
+	return len(*s)
+}
+
+// Unshift prepends one or more values to the beginning of the slice, updating the original slice.
+// It returns the new length of the slice.
+//
+// Parameters:
+//   - value: One or more values of type T to be added to the beginning of the slice.
+//
+// Returns:
+//   - length: The new length of the slice after the values have been prepended.
+func (s *Slice[T]) Unshift(value ...T) (length int) {
+	rawSlice := s.ToRaw()
+	length = Unshift(&rawSlice, value...)
+	*s = NewSlice(rawSlice...)
+	return length
+}

--- a/slices_test.go
+++ b/slices_test.go
@@ -1206,5 +1206,63 @@ func TestToReversed(t *testing.T) {
 			})
 		}
 	})
+}
 
+func TestShift(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialSlice   []int
+		expectedResult int
+		expectedOk     bool
+		expectedSlice  []int
+	}{{
+		name:           "Shift from non-empty slice",
+		initialSlice:   []int{1, 2, 3},
+		expectedResult: 1,
+		expectedOk:     true,
+		expectedSlice:  []int{2, 3},
+	}, {
+		name:           "Shift single-element slice",
+		initialSlice:   []int{10},
+		expectedResult: 10,
+		expectedOk:     true,
+		expectedSlice:  []int{},
+	}, {
+		name:           "Shift empty slice",
+		initialSlice:   []int{},
+		expectedResult: 0, // Default value for int
+		expectedOk:     false,
+		expectedSlice:  []int{},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("standalone function", func(t *testing.T) {
+				s := make([]int, len(tt.initialSlice))
+				copy(s, tt.initialSlice)
+
+				gotResult, gotOk := Shift(&s)
+				if gotResult != tt.expectedResult || gotOk != tt.expectedOk {
+					t.Errorf("Shift() = (%v, %v), want (%v, %v)", gotResult, gotOk, tt.expectedResult, tt.expectedOk)
+				}
+
+				if !reflect.DeepEqual(s, tt.expectedSlice) {
+					t.Errorf("resulting slice = %v, want %v", s, tt.expectedSlice)
+				}
+			})
+
+			t.Run("method on Slice", func(t *testing.T) {
+				s := NewSlice[int](tt.initialSlice...)
+				gotResult, gotOk := s.Shift()
+
+				if gotResult != tt.expectedResult || gotOk != tt.expectedOk {
+					t.Errorf("Slice.Shift() = (%v, %v), want (%v, %v)", gotResult, gotOk, tt.expectedResult, tt.expectedOk)
+				}
+
+				if !reflect.DeepEqual(s.ToRaw(), tt.expectedSlice) {
+					t.Errorf("resulting Slice = %v, want %v", s, tt.expectedSlice)
+				}
+			})
+		})
+	}
 }

--- a/slices_test.go
+++ b/slices_test.go
@@ -1266,3 +1266,61 @@ func TestShift(t *testing.T) {
 		})
 	}
 }
+
+func TestUnshift(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialSlice   []int
+		valuesToAdd    []int
+		expectedSlice  []int
+		expectedLength int
+	}{{
+		name:           "unshift to empty slice",
+		initialSlice:   []int{},
+		valuesToAdd:    []int{1, 2, 3},
+		expectedSlice:  []int{1, 2, 3},
+		expectedLength: 3,
+	}, {
+		name:           "unshift single value",
+		initialSlice:   []int{4, 5, 6},
+		valuesToAdd:    []int{1},
+		expectedSlice:  []int{1, 4, 5, 6},
+		expectedLength: 4,
+	}, {
+		name:           "unshift multiple values",
+		initialSlice:   []int{3, 4},
+		valuesToAdd:    []int{1, 2},
+		expectedSlice:  []int{1, 2, 3, 4},
+		expectedLength: 4,
+	}, {
+		name:           "unshift empty values to slice",
+		initialSlice:   []int{7, 8, 9},
+		valuesToAdd:    []int{},
+		expectedSlice:  []int{7, 8, 9},
+		expectedLength: 3,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("standalone function", func(t *testing.T) {
+				s := make([]int, len(tt.initialSlice))
+				copy(s, tt.initialSlice)
+
+				gotLength := Unshift(&s, tt.valuesToAdd...)
+				if !reflect.DeepEqual(s, tt.expectedSlice) || gotLength != tt.expectedLength {
+					t.Errorf("Unshift() got slice=%v length=%d, want slice=%v length=%d",
+						s, gotLength, tt.expectedSlice, tt.expectedLength)
+				}
+			})
+
+			t.Run("method on Slice", func(t *testing.T) {
+				s := NewSlice[int](tt.initialSlice...)
+				gotLength := s.Unshift(tt.valuesToAdd...)
+				if !reflect.DeepEqual(s.ToRaw(), tt.expectedSlice) || gotLength != tt.expectedLength {
+					t.Errorf("Unshift() got slice=%v length=%d, want slice=%v length=%d",
+						s, gotLength, tt.expectedSlice, tt.expectedLength)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
## New Features

Introduced two new operations: Shift() to remove and return the first element of a slice, and Unshift() to prepend one or more values to the beginning of a slice.

## Documentation

Updated the README to include descriptions of the new Shift() and Unshift() methods for the Slice type.

## Tests

Added comprehensive test cases for the Shift and Unshift operations, covering various scenarios to ensure functionality.